### PR TITLE
context aware

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -14,11 +15,11 @@ var (
 	log = golog.LoggerFor("proxy")
 )
 
-type DialFunc func(network, addr string) (conn net.Conn, err error)
+type DialFunc func(ctx context.Context, network, addr string) (conn net.Conn, err error)
 
 // Interceptor is a function that will intercept a connection to an HTTP server
 // and start proxying traffic. If proxying fails, it will return an error.
-type Interceptor func(w http.ResponseWriter, req *http.Request) error
+type Interceptor func(ctx context.Context, w http.ResponseWriter, req *http.Request) error
 
 func addIdleKeepAlive(header http.Header, idleTimeout time.Duration) {
 	if idleTimeout > 0 {

--- a/proxy_connect.go
+++ b/proxy_connect.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"net"
@@ -53,7 +54,7 @@ type connectInterceptor struct {
 	dial         DialFunc
 }
 
-func (ic *connectInterceptor) connect(w http.ResponseWriter, req *http.Request) error {
+func (ic *connectInterceptor) connect(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
 	var downstream net.Conn
 	var upstream net.Conn
 	var err error
@@ -76,7 +77,7 @@ func (ic *connectInterceptor) connect(w http.ResponseWriter, req *http.Request) 
 	// Note - for CONNECT requests, we use the Host from the request URL, not the
 	// Host header. See discussion here:
 	// https://ask.wireshark.org/questions/22988/http-host-header-with-and-without-port-number
-	upstream, err = ic.dial("tcp", req.URL.Host)
+	upstream, err = ic.dial(ctx, "tcp", req.URL.Host)
 	if err != nil {
 		fullErr := errors.New("Unable to dial upstream: %s", err)
 		log.Debug(fullErr)

--- a/proxy_http.go
+++ b/proxy_http.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"io/ioutil"
 	"net"
@@ -77,13 +78,19 @@ type httpInterceptor struct {
 	dial                DialFunc
 }
 
-func (ic *httpInterceptor) intercept(w http.ResponseWriter, req *http.Request) error {
+func (ic *httpInterceptor) intercept(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
 	var downstream net.Conn
 	var downstreamBuffered *bufio.ReadWriter
 	tr := &http.Transport{
-		Dial:                ic.dial,
-		IdleConnTimeout:     ic.idleTimeout,
-		MaxIdleConnsPerHost: 1, // since we have one transport per downstream connection, we don't need more than this
+		// Note: don't use DialContext here, as the Transport is used on its own,
+		// instead of by http.Client.
+		Dial: func(net, addr string) (net.Conn, error) {
+			return ic.dial(ctx, net, addr)
+		},
+		IdleConnTimeout: ic.idleTimeout,
+		// since we have one transport per downstream connection, we don't need
+		// more than this
+		MaxIdleConnsPerHost: 1,
 	}
 	var err error
 

--- a/proxy_http.go
+++ b/proxy_http.go
@@ -82,8 +82,8 @@ func (ic *httpInterceptor) intercept(ctx context.Context, w http.ResponseWriter,
 	var downstream net.Conn
 	var downstreamBuffered *bufio.ReadWriter
 	tr := &http.Transport{
-		// Note: don't use DialContext here, as the Transport is used on its own,
-		// instead of by http.Client.
+		// Note: set Dial instead of DialContext here as we want to cancel with
+		// the ctx passed in, instead of the context with the request.
 		Dial: func(net, addr string) (net.Conn, error) {
 			return ic.dial(ctx, net, addr)
 		},


### PR DESCRIPTION
Change the interface to accept `context.Context`, to gain the flexibility to cancel dialing any time. It breaks API so we need to update `http-proxy` too.