### PR TITLE
fix for chrome to respond immediately with OK to CONNECT requests

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -15,6 +15,7 @@ var (
 	log = golog.LoggerFor("proxy")
 )
 
+// DialFunc is the dial function to use for dialing the proxy.
 type DialFunc func(ctx context.Context, network, addr string) (conn net.Conn, err error)
 
 // Interceptor is a function that will intercept a connection to an HTTP server

--- a/proxy_connect.go
+++ b/proxy_connect.go
@@ -77,9 +77,9 @@ func (ic *connectInterceptor) connect(ctx context.Context, w http.ResponseWriter
 	// Hijack underlying connection.
 	downstream, _, err = w.(http.Hijacker).Hijack()
 	if err != nil {
-		// If there's an error hijacking, that's almost certainly because the
-		// connection has died, so there's no point in trying to send some sort
-		// of error response.
+		// If there's an error hijacking, it's because the connection has already
+		// been hijacked (a programming error). Not much we can do other than
+		// return an error.
 		fullErr := errors.New("Unable to hijack connection: %s", err)
 		log.Error(fullErr)
 		return fullErr

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -73,7 +72,7 @@ func TestDialFailureCONNECT(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	assert.Equal(t, fmt.Sprintf("Unable to dial upstream: %v", errorText), string(body))
+	assert.Equal(t, errorText, string(body))
 }
 
 func TestDialWithTimeout(t *testing.T) {
@@ -100,7 +99,7 @@ func TestDialWithTimeout(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	assert.Equal(t, "Unable to dial upstream: context deadline exceeded", string(body))
+	assert.Equal(t, "context deadline exceeded", string(body))
 }
 
 func TestCONNECT(t *testing.T) {


### PR DESCRIPTION
This changes our proxy handling on both the client and the server to always immediately respond with an OK to a CONNECT request.