### PR TITLE
close response body if fail to send downstream

### DIFF
--- a/proxy_http.go
+++ b/proxy_http.go
@@ -118,14 +118,15 @@ func (ic *httpInterceptor) processRequests(remoteAddr string, req *http.Request,
 
 	first := true
 	for {
+		ic.onRequest(req)
 		discardRequest := first && ic.discardFirstRequest
 		if discardRequest {
-			err := ic.onRequest(req).Write(ioutil.Discard)
+			err := req.Write(ioutil.Discard)
 			if err != nil {
 				return errors.New("Error discarding first request: %v", err)
 			}
 		} else {
-			resp, err := tr.RoundTrip(prepareRequest(ic.onRequest(req)))
+			resp, err := tr.RoundTrip(prepareRequest(req))
 			if err != nil {
 				errResp := ic.onError(req, err)
 				if errResp != nil {

--- a/proxy_http.go
+++ b/proxy_http.go
@@ -118,15 +118,15 @@ func (ic *httpInterceptor) processRequests(remoteAddr string, req *http.Request,
 
 	first := true
 	for {
-		ic.onRequest(req)
+		modifiedReq := ic.onRequest(req)
 		discardRequest := first && ic.discardFirstRequest
 		if discardRequest {
-			err := req.Write(ioutil.Discard)
+			err := modifiedReq.Write(ioutil.Discard)
 			if err != nil {
 				return errors.New("Error discarding first request: %v", err)
 			}
 		} else {
-			resp, err := tr.RoundTrip(prepareRequest(req))
+			resp, err := tr.RoundTrip(prepareRequest(modifiedReq))
 			if err != nil {
 				errResp := ic.onError(req, err)
 				if errResp != nil {

--- a/proxy_http.go
+++ b/proxy_http.go
@@ -174,7 +174,13 @@ func (ic *httpInterceptor) writeResponse(downstream io.Writer, resp *http.Respon
 	} else {
 		resp = ic.onResponse(prepareResponse(resp, belowHTTP11))
 	}
-	return resp.Write(out)
+	err := resp.Write(out)
+	// resp.Write closes the body only if it's successfully sent. Close
+	// manually when error happens.
+	if err != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	return err
 }
 
 // prepareRequest prepares the request in line with the HTTP spec for proxies.

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
+	ht "net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -111,6 +113,81 @@ func TestHTTPForwardFirst(t *testing.T) {
 
 func TestHTTPDontForwardFirst(t *testing.T) {
 	doTest(t, "GET", true, false)
+}
+
+type failingConn struct {
+	net.Conn
+}
+
+func (c failingConn) Write(b []byte) (n int, err error) {
+	return 0, fmt.Errorf("fail intentionally: %s->%s",
+		c.Conn.LocalAddr().String(),
+		c.Conn.RemoteAddr().String())
+}
+
+type failingHijacker struct {
+	http.ResponseWriter
+}
+
+func (h failingHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	n, rw, e := h.ResponseWriter.(http.Hijacker).Hijack()
+	return failingConn{n}, rw, e
+}
+
+func TestHTTPDownstreamError(t *testing.T) {
+	origin := ht.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("hello"))
+	}))
+	defer origin.Close()
+
+	intercept := HTTP(false, 30*time.Second, nil, nil, nil, func(network, addr string) (net.Conn, error) {
+		return net.Dial("tcp", origin.Listener.Addr().String())
+	})
+	proxy := ht.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		intercept(failingHijacker{w}, req)
+	}))
+	defer proxy.Close()
+
+	_, counter, err := fdcount.Matching("TCP")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	n := 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	chConnsToClose := make(chan net.Conn, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			conn, err := net.Dial("tcp", proxy.Listener.Addr().String())
+			chConnsToClose <- conn
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			req, _ := http.NewRequest("GET", origin.URL, nil)
+			err = req.Write(conn)
+			if !assert.NoError(t, err) {
+				return
+			}
+			br := bufio.NewReader(conn)
+			_, rtErr := http.ReadResponse(br, req)
+			if !assert.Error(t, rtErr) {
+				return
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.NoError(t, counter.AssertDelta(n),
+		"All connections should have been closed but the CLOSE_WAIT one from client to proxy")
+	for i := 0; i < n; i++ {
+		if conn := <-chConnsToClose; conn != nil {
+			conn.Close()
+		}
+	}
+	assert.NoError(t, counter.AssertDelta(0), "All connections should have been closed")
 }
 
 func doTest(t *testing.T, requestMethod string, discardFirstRequest bool, okWaitsForUpstream bool) {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -124,7 +124,7 @@ func doTest(t *testing.T, requestMethod string, discardFirstRequest bool, okWait
 	if !assert.NoError(t, err) {
 		return
 	}
-	defer l.Close()
+	defer pl.Close()
 
 	var mx sync.RWMutex
 	seenAddresses := make(map[string]bool)


### PR DESCRIPTION
For https://github.com/getlantern/lantern-internal/issues/909#issuecomment-306480036

Test code is pending as it requires replicating most of the `doTest` code.