### PR TITLE
Adds tracing to core proxying code

### DIFF
--- a/proxy_connect.go
+++ b/proxy_connect.go
@@ -77,7 +77,7 @@ func (proxy *proxy) nextCONNECT(downstream net.Conn) filters.Next {
 			return resp, nextCtx, nil
 		}
 
-		_, span := trace.StartSpan(context.Background(), fmt.Sprintf("connect dial:%v", modifiedReq.Host))
+		_, span := trace.StartSpan(ctx, fmt.Sprintf("connect dial:%v", modifiedReq.Host))
 		defer span.End()
 
 		// Note - for CONNECT requests, we use the Host from the request URL, not the
@@ -116,7 +116,7 @@ func (proxy *proxy) Connect(ctx context.Context, in io.Reader, conn net.Conn, or
 }
 
 func (proxy *proxy) proceedWithConnect(ctx filters.Context, req *http.Request, upstreamAddr string, upstream net.Conn, downstream net.Conn) error {
-	_, span := trace.StartSpan(context.Background(), fmt.Sprintf("connect roundtrip:%v", req.Host))
+	_, span := trace.StartSpan(ctx, fmt.Sprintf("connect roundtrip:%v", req.Host))
 	defer span.End()
 	if upstream == nil {
 		var dialErr error

--- a/proxy_connect.go
+++ b/proxy_connect.go
@@ -77,7 +77,7 @@ func (proxy *proxy) nextCONNECT(downstream net.Conn) filters.Next {
 			return resp, nextCtx, nil
 		}
 
-		_, span := trace.StartSpan(context.Background(), fmt.Sprintf("connect:%v", modifiedReq.Host))
+		_, span := trace.StartSpan(context.Background(), fmt.Sprintf("connect dial:%v", modifiedReq.Host))
 		defer span.End()
 
 		// Note - for CONNECT requests, we use the Host from the request URL, not the
@@ -116,6 +116,8 @@ func (proxy *proxy) Connect(ctx context.Context, in io.Reader, conn net.Conn, or
 }
 
 func (proxy *proxy) proceedWithConnect(ctx filters.Context, req *http.Request, upstreamAddr string, upstream net.Conn, downstream net.Conn) error {
+	_, span := trace.StartSpan(context.Background(), fmt.Sprintf("connect roundtrip:%v", req.Host))
+	defer span.End()
 	if upstream == nil {
 		var dialErr error
 		upstream, dialErr = proxy.Dial(ctx, true, "tcp", upstreamAddr)

--- a/proxy_http.go
+++ b/proxy_http.go
@@ -132,7 +132,7 @@ func (proxy *proxy) handle(ctx context.Context, downstreamIn io.Reader, downstre
 
 		defer tr.CloseIdleConnections()
 		next = func(ctx filters.Context, modifiedReq *http.Request) (*http.Response, filters.Context, error) {
-			_, span := trace.StartSpan(context.Background(), fmt.Sprintf("http:%v", modifiedReq.Host))
+			_, span := trace.StartSpan(context.Background(), fmt.Sprintf("http roundtrip:%v", modifiedReq.Host))
 			defer span.End()
 			modifiedReq = modifiedReq.WithContext(ctx)
 			setRequestForAwareConn(ctx, modifiedReq)

--- a/proxy_http.go
+++ b/proxy_http.go
@@ -132,7 +132,7 @@ func (proxy *proxy) handle(ctx context.Context, downstreamIn io.Reader, downstre
 
 		defer tr.CloseIdleConnections()
 		next = func(ctx filters.Context, modifiedReq *http.Request) (*http.Response, filters.Context, error) {
-			_, span := trace.StartSpan(context.Background(), fmt.Sprintf("go: %v", modifiedReq.Host))
+			_, span := trace.StartSpan(context.Background(), fmt.Sprintf("http:%v", modifiedReq.Host))
 			defer span.End()
 			modifiedReq = modifiedReq.WithContext(ctx)
 			setRequestForAwareConn(ctx, modifiedReq)

--- a/proxy_http.go
+++ b/proxy_http.go
@@ -132,7 +132,7 @@ func (proxy *proxy) handle(ctx context.Context, downstreamIn io.Reader, downstre
 
 		defer tr.CloseIdleConnections()
 		next = func(ctx filters.Context, modifiedReq *http.Request) (*http.Response, filters.Context, error) {
-			_, span := trace.StartSpan(context.Background(), fmt.Sprintf("http roundtrip:%v", modifiedReq.Host))
+			_, span := trace.StartSpan(ctx, fmt.Sprintf("http roundtrip:%v", modifiedReq.Host))
 			defer span.End()
 			modifiedReq = modifiedReq.WithContext(ctx)
 			setRequestForAwareConn(ctx, modifiedReq)


### PR DESCRIPTION
Our use of this is a little abnormal in the sense that we're tracing traffic that's largely hitting other people's infrastructure on destination sites, but nevertheless it seems like it might be useful. Without credential set, these should effectively be no-ops.