### PR TITLE
always save initial request in context

### DIFF
--- a/proxy_http.go
+++ b/proxy_http.go
@@ -93,10 +93,7 @@ func (proxy *proxy) handle(ctx context.Context, downstreamIn io.Reader, downstre
 			req.RemoteAddr = remoteAddr.String()
 		}
 		if origURLScheme(ctx) == "" {
-			fctx = fctx.
-				WithValue(ctxKeyOrigURLScheme, req.URL.Scheme).
-				WithValue(ctxKeyOrigURLHost, req.URL.Host).
-				WithValue(ctxKeyOrigHost, req.Host)
+			fctx = fctx.WithValue(CtxKeyInitialRequest, req)
 		}
 	}
 


### PR DESCRIPTION
For https://github.com/getlantern/lantern-internal/issues/3047 so the filters for subsequent requests in a persistent connection can retrieve the Lantern version from the initial request and redirect to the outdated page when required.