### PR TITLE
Treat closed pipe errors as expected

### DIFF
--- a/proxy_http.go
+++ b/proxy_http.go
@@ -448,6 +448,7 @@ func isUnexpected(err error) bool {
 		!strings.Contains(text, "use of closed network connection") &&
 		// usually caused by client disconnecting
 		!strings.Contains(text, "broken pipe") &&
+		!strings.Contains(text, "closed pipe") &&
 		// usually caused by client disconnecting
 		!strings.Contains(text, "connection reset by peer")
 }


### PR DESCRIPTION
We're seeing a lot of errors like "Error piping data to upstream at 23.7.172.185:443: io: read/write on closed pipe". I _think_ this is just the origin prematurely closing the connection, so we don't need to log this as an error. I've logged https://github.com/getlantern/lantern-internal/issues/3899 to separately validate this claim.