### PR TITLE
Coalesce http response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: go
 go:
-- 1.10.2
+- 1.14.4
 install:
 - go get golang.org/x/tools/cmd/cover
 - go get -v github.com/axw/gocov/gocov
 - go get -v github.com/mattn/goveralls
 - go get -t
 script:
-- GOPATH=`pwd`:$GOPATH; go test -race -v -covermode=atomic -coverprofile=profile_tmp github.com/getlantern/proxy/... && tail -n +2 profile_tmp >> profile.cov && tail -n +2 profile_tmp >> profile.cov
+- go test -race -v -covermode=atomic -coverprofile=profile_tmp github.com/getlantern/proxy/... && tail -n +2 profile_tmp >> profile.cov && tail -n +2 profile_tmp >> profile.cov
 after_success:
-- GOPATH=`pwd`:$GOPATH $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci
+- $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/getlantern/preconn v0.0.0-20180328114929-0b5766010efe
 	github.com/getlantern/reconn v0.0.0-20161128113912-7053d017511c
 	github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4
+	github.com/getlantern/waitforserver v1.0.1
+	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/mitchellh/go-server-timing v1.0.0
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -46,10 +46,14 @@ github.com/getlantern/reconn v0.0.0-20161128113912-7053d017511c h1:IkjF+RwRs8B/R
 github.com/getlantern/reconn v0.0.0-20161128113912-7053d017511c/go.mod h1:kExwbqTx1krUnT9ohmXG3jayDTEBfxUKeoRzU6XucLw=
 github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4 h1:73U3J4msGw3cXeKtCEbY7hbOdD6aX8gJv8BOu+VagF8=
 github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4/go.mod h1:f8WmDYKFOaC5/y0d3GWl6UKf1ZbSlIoMzkuC8x7pUhg=
+github.com/getlantern/waitforserver v1.0.1 h1:xBjqJ3GgEk9JMWnDgRSiNHXINi6Lv2tGNjJR0hCkHFY=
+github.com/getlantern/waitforserver v1.0.1/go.mod h1:K1oSA8lNKgQ9iC00OFpMfMNm4UMrsxoGCdHf0NT9LGs=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/golang/gddo v0.0.0-20180823221919-9d8ff1c67be5 h1:yrv1uUvgXH/tEat+wdvJMRJ4g51GlIydtDpU9pFjaaI=
 github.com/golang/gddo v0.0.0-20180823221919-9d8ff1c67be5/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/mitchellh/go-server-timing v1.0.0 h1:cdHk4f7lxjwbRqTSGZFw8PCeoNYXGp4T4Sdr8wT+Xlw=
 github.com/mitchellh/go-server-timing v1.0.0/go.mod h1:RdipKQzCJaL4HyxFQBINbf4XoDdZKkSshqw9Bbsx1ic=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=

--- a/proxy_http.go
+++ b/proxy_http.go
@@ -315,7 +315,10 @@ func (proxy *proxy) writeResponse(downstream io.Writer, req *http.Request, resp 
 		resp = prepareResponse(resp, belowHTTP11)
 		proxy.addIdleKeepAlive(resp.Header)
 	}
-	err := resp.Write(out)
+
+	bout := bufio.NewWriter(out)
+	err := resp.Write(bout)
+	bout.Flush()
 	// resp.Write closes the body only if it's successfully sent. Close
 	// manually when error happens.
 	if err != nil && resp.Body != nil {

--- a/proxy_http.go
+++ b/proxy_http.go
@@ -318,7 +318,13 @@ func (proxy *proxy) writeResponse(downstream io.Writer, req *http.Request, resp 
 
 	bout := bufio.NewWriter(out)
 	err := resp.Write(bout)
-	bout.Flush()
+	// always try to flush what we have
+	err1 := bout.Flush()
+	// take first error
+	if err == nil {
+		err = err1
+	}
+
 	// resp.Write closes the body only if it's successfully sent. Close
 	// manually when error happens.
 	if err != nil && resp.Body != nil {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -811,7 +811,12 @@ func TestPipeliningWithIdleTimingServer(t *testing.T) {
 			}
 			t.Log("Server Accepted")
 			go func() {
-				go io.Copy(ioutil.Discard, conn)
+				defer conn.Close()
+				br := bufio.NewReader(conn)
+				_, err := http.ReadRequest(br)
+				if err != nil {
+					return
+				}
 				resp := &http.Response{
 					ProtoMajor: 1,
 					ProtoMinor: 1,
@@ -820,7 +825,6 @@ func TestPipeliningWithIdleTimingServer(t *testing.T) {
 					Close:      false,
 				}
 				resp.Write(conn)
-				conn.Close()
 			}()
 		}
 	}()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/getlantern/mockconn"
 	"github.com/getlantern/proxy/filters"
 	"github.com/getlantern/tlsdefaults"
+	"github.com/getlantern/waitforserver"
 	servertiming "github.com/mitchellh/go-server-timing"
 	"github.com/stretchr/testify/assert"
 )
@@ -73,6 +74,11 @@ func TestRequestAware(t *testing.T) {
 	const addr = "127.0.0.1:3000"
 	var conn net.Conn
 	var err error
+	defer func() {
+		if conn != nil {
+			conn.Close()
+		}
+	}()
 	pr, err := New(&Opts{
 		Dial: func(context context.Context, isConnect bool, transport, addr string) (net.Conn, error) {
 			conn, err = net.Dial(transport, addr)
@@ -88,14 +94,13 @@ func TestRequestAware(t *testing.T) {
 
 	var serverRequest *http.Request
 
-	var server *http.Server
-	go func() {
-		http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
-			serverRequest = req
-		})
-		server = &http.Server{Addr: addr}
-		server.ListenAndServe()
-	}()
+	server := &http.Server{Addr: addr, Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		serverRequest = req
+	})}
+	defer server.Close()
+	go server.ListenAndServe()
+
+	waitforserver.WaitForServer("tcp", addr, 5*time.Second)
 
 	var tr idleClosingTransport = &http.Transport{
 		DialContext: p.requestAwareDial,
@@ -112,8 +117,6 @@ func TestRequestAware(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "true", serverRequest.Header.Get("x-aware"))
-	conn.Close()
-	server.Close()
 }
 
 func TestDialFailureHTTP(t *testing.T) {


### PR DESCRIPTION
This buffers writing plain http responses (not CONNECT traffic) a bit (up to 4k) to avoid writing many tiny packets.
Prior to this, many parts of http responses could be observed as individual packets (or at best multiple tls frames in a packet when the tcp coalesces some) -- eg the status line in its own packet, each header split into two or more packets corresponding to how the http response writes chunks of data out.