### PR TITLE
Optimized ctext by updating values in place

### DIFF
--- a/filters/context_test.go
+++ b/filters/context_test.go
@@ -19,25 +19,29 @@ func TestContext(t *testing.T) {
 }
 
 func BenchmarkRegularContext(b *testing.B) {
-	ctx := context.Background()
+	rootKey := "root"
 	key := "key"
+	ctx := context.WithValue(context.Background(), rootKey, "r")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ctx = context.WithValue(ctx, key, i)
 		for j := 0; j < 10; j++ {
 			ctx.Value(key)
+			ctx.Value(rootKey)
 		}
 	}
 }
 
 func BenchmarkAdaptedContext(b *testing.B) {
-	ctx := AdaptContext(context.Background())
+	rootKey := "root"
 	key := "key"
+	ctx := AdaptContext(context.WithValue(context.Background(), rootKey, "r"))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ctx = ctx.WithValue(key, i)
 		for j := 0; j < 10; j++ {
 			ctx.Value(key)
+			ctx.Value(rootKey)
 		}
 	}
 }

--- a/filters/context_test.go
+++ b/filters/context_test.go
@@ -1,0 +1,43 @@
+package filters
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContext(t *testing.T) {
+	ctx := context.WithValue(context.WithValue(context.Background(), 1, "one"), "b", "bee")
+	adapted := AdaptContext(ctx).WithValue("c", "cee")
+	require.Equal(t, "one", adapted.Value(1))
+	require.Equal(t, "bee", adapted.Value("b"))
+	require.Equal(t, "cee", adapted.Value("c"))
+	adapted = adapted.WithValue("c", "cee2")
+	require.Equal(t, "cee2", adapted.Value("c"))
+	require.Equal(t, nil, adapted.Value("d"))
+}
+
+func BenchmarkRegularContext(b *testing.B) {
+	ctx := context.Background()
+	key := "key"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctx = context.WithValue(ctx, key, i)
+		for j := 0; j < 10; j++ {
+			ctx.Value(key)
+		}
+	}
+}
+
+func BenchmarkAdaptedContext(b *testing.B) {
+	ctx := AdaptContext(context.Background())
+	key := "key"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctx = ctx.WithValue(key, i)
+		for j := 0; j < 10; j++ {
+			ctx.Value(key)
+		}
+	}
+}


### PR DESCRIPTION
This is an alternative to #50 that leaves the API unchanged except for a semantic distinction that `WithValue` no longer copies the context but alters it in place.

- [ ] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Do we know how we’re going to deploy this?
- [ ] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?